### PR TITLE
Fix "params" relative path processing

### DIFF
--- a/pcbdraw/populate.py
+++ b/pcbdraw/populate.py
@@ -226,7 +226,7 @@ def relativize_header_paths(header, to):
     if "params" in header:
         for i, arg in enumerate(header["params"]):
             for key in ["--style", "--remap"]:
-                c = find_command(arg, key)
+                c = find_command([arg], key)
                 if c is None:
                     continue
                 y = c.split(" ")


### PR DESCRIPTION
The first argument for find_command must be a list.
Introduced by yaqwsx/PcbDraw@f614fcc